### PR TITLE
.Cfg dir is now correctly created.

### DIFF
--- a/py_client/notify_run/__init__.py
+++ b/py_client/notify_run/__init__.py
@@ -1,5 +1,5 @@
 from os import environ, makedirs
-from os.path import expanduser, basename
+from os.path import expanduser, dirname 
 import json
 import requests
 from pyqrcode import QRCode
@@ -89,7 +89,7 @@ class Notify:
 
     def write_config(self):
         try:
-            makedirs(basename(self._config_file))
+            makedirs(dirname(self._config_file))
         except OSError:
             # file exists
             pass


### PR DESCRIPTION
This fixes the handling of the config directory creation in case it doesn't exist.

Assuming the config file name is ` ~/.config/notify-run,` the call to `os.path.basename` in line 92 returned 'notify-run' ([os.path.basename](https://docs.python.org/2/library/os.path.html#os.path.basename) returns the last pathname component).
So instead of creating a config directory, the call `makedirs(basename(self._config_file))`, created a directory named 'notify-run' in the current working directory.
Because the config directory wasn't created - an exception was raised while attempting to open '\~/.config/notify-run' (line 101).

replacing os.pathp.basename with [os.path.dirname](https://docs.python.org/2/library/os.path.html#os.path.dirname) fixes the problem by passing the path of the config directory to makedirs (~/.config, instead of notify-run), and makes sure the config directory exists before opening the config file for writing.

I guess this didn't came up, because usually the config directory already exists (~/.config is a pretty common config directory for most packages and one of them probably created it) but under any 'clean' environment (mostly windows) this would cause errors.

![image](https://user-images.githubusercontent.com/40582199/43666592-257776a2-977d-11e8-8a96-872d2ad7d782.png)


Could this have been done better?