### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/paulgb/notify.run.svg?branch=master)](https://travis-ci.org/paulgb/notify.run)
 
-<img src="site/static-src/icon.png" height="30" /> notify.run
+<img src="https://avatars2.githubusercontent.com/u/53474526?s=200&v=4" height="30" /> notify.run
 ============================================================
 
 **[notify.run](https://notify.run) makes it easy to programmatically send notifications to your own phone or desktop.** It is provided as a free web service that can be used without installation (on both the sending and receiving end). This repository contains the source of the web service, as well as a Python client that provides integration with Jupyter and Keras.
@@ -11,4 +11,4 @@ This repository contains the source code for the Python client, website, and ser
 
 - **If you are interested in using the public instance of notify.run to send notifications to yourself, you don’t need to download anything from this repo.** Just follow the instructions at [notify.run](https://notify.run).
 - If you are interested in using the Python client to send notifications via notify.run, see [py_client/README.rst](py_client/README.rst).
-- If you are interested in self-hosting your own notify.run server, see [server/README.rst](server/README.rst).
+- If you are interested in self-hosting your own notify.run server, see [notify-run-server](https://github.com/notify-run/notify-run-server).


### PR DESCRIPTION
After the repo reorg the link to the server code did not work any longer (and the logo in the readme). This pr fixes these two.

Thanks also for the Dockerfile at https://github.com/notify-run/notify-run-deployment, will need to look into this later, as I was always a bit put off by the impression that I need to use dynamodb for this service.