### PR TITLE
create Notify.is_registered property

### DIFF
--- a/py_client/notify_run/__init__.py
+++ b/py_client/notify_run/__init__.py
@@ -146,3 +146,7 @@ class Notify:
         self.endpoint = r['endpoint']
         self.write_config()
         return EndpointInfo(r)
+    
+    @property
+    def is_registered(self):
+        return self.endpoint is not None


### PR DESCRIPTION
Use to provide users more intutive access to the state of their Notify object